### PR TITLE
Fix the method for including controller in router

### DIFF
--- a/routing/Router.php
+++ b/routing/Router.php
@@ -181,7 +181,7 @@ class Router {
 		$this->currentController = $controller_file;
 		$this->currentAction = $action_function;
 		if ($direct) {
-			include($controller_file . ".php");
+			include_once($controller_file . ".php");
 			$this->perfmon(false);
 			if ($action_function)
 				call_user_func_array($action_function, $args);
@@ -189,7 +189,7 @@ class Router {
 		else {
 			$cls = $controller_file . "Controller";
 			if (!class_exists($cls))
-				include($this->controller_path . "/" . $cls . ".php");
+				include_once($this->controller_path . "/" . $cls . ".php");
 			$i = strrchr($cls, "/");
 			$clsname = $i ? substr($i, 1) : $cls;
 			$this->perfmon(false);

--- a/routing/Router.php
+++ b/routing/Router.php
@@ -62,13 +62,10 @@ class Router {
 			"method" => $method,
 			"uri" => $uri,
 			"controller_action" => $controller_action,
-			"direct" => FALSE,
 			"conditions" => array(),
 			"arguments" => array(),
 			"sitemap" => FALSE
 		);
-        if (isset($options["direct"]))
-            $entry["direct"] = TRUE;
         if (isset($options["force_redirect"]))
             $entry["force_redirect"] = $options["force_redirect"];
         if (isset($options["fullpath_base"]))
@@ -138,7 +135,6 @@ class Router {
 		$uri = trim($uri, '/');
 		$controller_action = $this->metaRoutes["404"];
 		$args = array();
-		$direct = FALSE;
 		$arguments = array();
 		foreach ($this->routes as $route) {
 			if ((($route["method"] == "*") || ($route["method"] == $method)) &&
@@ -156,7 +152,6 @@ class Router {
 				        return;
 				    }
 					$controller_action = $route["controller_action"];
-					$direct = $route["direct"];
 					$arguments = $route["arguments"];
 					array_shift($matches);
 					$args = $matches;
@@ -165,10 +160,10 @@ class Router {
 			}
 		}
 		$this->perfmon(false);
-		$this->dispatchControllerAction($controller_action, $args, $direct, $arguments);
+		$this->dispatchControllerAction($controller_action, $args, $arguments);
 	}
 		
-	public function dispatchControllerAction($controller_action, $args = array(), $direct = FALSE, $arguments = array()) {
+	public function dispatchControllerAction($controller_action, $args = array(), $arguments = array()) {
 		$this->perfmon(true);
 		$this->log(Logger::INFO_2, "Dispatch Action: " . $controller_action);
 		krsort($arguments);
@@ -180,23 +175,16 @@ class Router {
 		@list($controller_file, $action_function) = explode("#", $controller_action);
 		$this->currentController = $controller_file;
 		$this->currentAction = $action_function;
-		if ($direct) {
-			include_once($controller_file . ".php");
-			$this->perfmon(false);
-			if ($action_function)
-				call_user_func_array($action_function, $args);
-		}
-		else {
-			$cls = $controller_file . "Controller";
-			if (!class_exists($cls))
-				include_once($this->controller_path . "/" . $cls . ".php");
-			$i = strrchr($cls, "/");
-			$clsname = $i ? substr($i, 1) : $cls;
-			$this->perfmon(false);
-			$controller = new $clsname();
-            $this->lastControllerInstance = $controller;
-			$controller->dispatch($action_function, $args);
-		}
+
+        $cls = $controller_file . "Controller";
+        if (!class_exists($cls))
+            include_once($this->controller_path . "/" . $cls . ".php");
+        $i = strrchr($cls, "/");
+        $clsname = $i ? substr($i, 1) : $cls;
+        $this->perfmon(false);
+        $controller = new $clsname();
+        $this->lastControllerInstance = $controller;
+        $controller->dispatch($action_function, $args);
 	}
 	
 	public function path($path) {


### PR DESCRIPTION
Previously, the router used `include` to evaluate the controller receiving
the method. Calling `include` worked perfectly on the server. Because
Apache started a new PHP environment for each request, `include` could
not be called twice on the same class file. However, running tests
with PHPunit maintains the same PHP environment for
the entire test suite. Routing to a controller more than once caused
reevaluation of the class, resulting in a "Cannot redeclare class"
error. Using `include_once` to initially evaluate the controller file
ensured PHP never attempted to redeclare the class, and fixed the bug.